### PR TITLE
CallKit QuickStart sample app improvements

### DIFF
--- a/VideoCallKitQuickStart/ViewController+CallKit.swift
+++ b/VideoCallKitQuickStart/ViewController+CallKit.swift
@@ -119,25 +119,17 @@ extension ViewController {
     func performStartCallAction(uuid: UUID, roomName: String?) {
         let callHandle = CXHandle(type: .generic, value: roomName ?? "")
         let startCallAction = CXStartCallAction(call: uuid, handle: callHandle)
+        
+        startCallAction.isVideo = true
+        
         let transaction = CXTransaction(action: startCallAction)
-
+        
         callKitCallController.request(transaction)  { error in
             if let error = error {
                 NSLog("StartCallAction transaction request failed: \(error.localizedDescription)")
                 return
             }
-
             NSLog("StartCallAction transaction request successful")
-
-            let callUpdate = CXCallUpdate()
-            callUpdate.remoteHandle = callHandle
-            callUpdate.supportsDTMF = false
-            callUpdate.supportsHolding = true
-            callUpdate.supportsGrouping = false
-            callUpdate.supportsUngrouping = false
-            callUpdate.hasVideo = true
-
-            self.callKitProvider.reportCall(with: uuid, updated: callUpdate)
         }
     }
 

--- a/VideoCallKitQuickStart/ViewController.swift
+++ b/VideoCallKitQuickStart/ViewController.swift
@@ -33,7 +33,7 @@ class ViewController: UIViewController {
     // CallKit components
     let callKitProvider:CXProvider
     let callKitCallController:CXCallController
-    var pendingAction:CXCallAction?
+    var callKitCompletionHandler: ((Bool)->Swift.Void?)? = nil
 
     // MARK: UI Element Outlets and handles
     @IBOutlet weak var remoteView: UIView!
@@ -228,13 +228,8 @@ extension ViewController : TVIRoomDelegate {
                 callKitProvider.reportOutgoingCall(with: uuid, connectedAt: nil)
             }
         }
-
-        // Mark the Start/Answer Call Action as being fullfilled
-        if let pendingAction = pendingAction {
-            pendingAction.fulfill()
-        }
-
-        pendingAction = nil
+        
+        self.callKitCompletionHandler!(true)
     }
     
     func room(_ room: TVIRoom, didDisconnectWithError error: Error?) {
@@ -242,21 +237,15 @@ extension ViewController : TVIRoomDelegate {
         
         self.cleanupRemoteParticipant()
         self.room = nil
-        
         self.showRoomUI(inRoom: false)
+        self.callKitCompletionHandler = nil
     }
     
     func room(_ room: TVIRoom, didFailToConnectWithError error: Error) {
         logMessage(messageText: "Failed to connect to room with error: \(error.localizedDescription)")
 
-        // Mark the Start/Answer Call Action as having failed
-        if let pendingAction = pendingAction {
-            pendingAction.fail()
-        }
-
-        pendingAction = nil
+        self.callKitCompletionHandler!(false)
         self.room = nil
-
         self.showRoomUI(inRoom: false)
     }
     


### PR DESCRIPTION
This PR has following changes -
1. StartCall - Avoid updating call.
2. Report `Connected` Call state to CallKit for outgoing call.
3. Disconnect from the Room on `providerDidReset` callback.
4. Following speakerbox's guidelines to configure audio session while simulating incoming call
