### PR TITLE
Using TwilioVideo 1.0.0-beta5

### DIFF
--- a/CustomScreenCapturerExample/ExampleScreenCapturer.swift
+++ b/CustomScreenCapturerExample/ExampleScreenCapturer.swift
@@ -162,13 +162,13 @@ class ExampleScreenCapturer: NSObject, TVIVideoCapturer {
         }
 
         // Deliver a VideoFrame to the consumer. Images drawn by UIGraphics do not need any rotation tags.
-        var frame = TVIVideoFrame()
-        frame.imageBuffer = Unmanaged<CVPixelBuffer>.passUnretained(pixelBuffer!)
-        frame.orientation = TVIVideoOrientation.up
         // Express timestamps in microseconds
-        frame.timestamp = Int64(timer.timestamp * Double( 1000000 ))
+        let timeStamp = Int64(timer.timestamp * Double( 1000000 ))
+        let frame = TVIVideoFrame(timestamp: timeStamp,
+                                  buffer: pixelBuffer!,
+                                  orientation: TVIVideoOrientation.up)
 
         // The consumer retains the CVPixelBuffer and will own it as the buffer flows through the video pipeline.
-        captureConsumer?.consumeCapturedFrame(frame)
+        captureConsumer?.consumeCapturedFrame(frame!)
     }
 }

--- a/Podfile
+++ b/Podfile
@@ -3,7 +3,7 @@ source 'https://github.com/twilio/cocoapod-specs'
 workspace 'VideoQuickStart'
 
 abstract_target 'TwilioVideo' do
-  pod 'TwilioVideo', '1.0.0-beta4'
+  pod 'TwilioVideo', '1.0.0-beta5'
 
   target 'VideoQuickStart' do
     project 'VideoQuickStart.xcproject'

--- a/VideoQuickStart/ViewController.swift
+++ b/VideoQuickStart/ViewController.swift
@@ -46,10 +46,6 @@ class ViewController: UIViewController {
 
         // LocalMedia represents the collection of tracks that we are sending to other Participants from our VideoClient.
         localMedia = TVILocalMedia()
-        
-        // 1.0.0-beta4 incorrectly chooses `TVIAudioOutputVoiceChatDefault` by default. We work around this by restoring the intended default value.
-        let audioController = localMedia?.audioController
-        audioController?.audioOutput = .videoChatDefault
 
         if PlatformUtils.isSimulator {
             self.previewView.removeFromSuperview()


### PR DESCRIPTION
- Uses 1.0.0-beta5
- Removed the audio route work around as Video SDK version 1.0.0-beta5 correctly chooses `TVIAudioOutputVideoChatDefault`  by default