### PR TITLE
Set room text field to lower case by default

### DIFF
--- a/VideoCallKitQuickStart/ViewController.swift
+++ b/VideoCallKitQuickStart/ViewController.swift
@@ -84,6 +84,7 @@ class ViewController: UIViewController {
         self.disconnectButton.isHidden = true
         self.micButton.isHidden = true
         
+        self.roomTextField.autocapitalizationType = .none
         self.roomTextField.delegate = self
         
         let tap = UITapGestureRecognizer(target: self, action: #selector(ViewController.dismissKeyboard))

--- a/VideoQuickStart/ViewController.swift
+++ b/VideoQuickStart/ViewController.swift
@@ -56,6 +56,7 @@ class ViewController: UIViewController {
         self.disconnectButton.isHidden = true
         self.micButton.isHidden = true
         
+        self.roomTextField.autocapitalizationType = .none
         self.roomTextField.delegate = self
         
         let tap = UITapGestureRecognizer(target: self, action: #selector(ViewController.dismissKeyboard))


### PR DESCRIPTION
When developers start by creating a token in the [Twilio console](https://www.twilio.com/console/video/runtime/testing-tools) and specify a room name when generating a token the default capitalization on the page is lower case while in this app it's upper case which can lead to confusion when getting started since room names are case sensitive