### PR TITLE
Tagging the pixel buffer with the correct frame format

### DIFF
--- a/ScreenCapturerExample/ExampleScreenCapturer.swift
+++ b/ScreenCapturerExample/ExampleScreenCapturer.swift
@@ -146,7 +146,7 @@ class ExampleScreenCapturer: NSObject, TVIVideoCapturer {
         let status = CVPixelBufferCreateWithBytes(nil,
                                                   (image?.width)!,
                                                   (image?.height)!,
-                                                  TVIPixelFormat.format32ARGB.rawValue,
+                                                  TVIPixelFormat.format32BGRA.rawValue,
                                                   UnsafeMutableRawPointer( mutating: baseAddress!),
                                                   (image?.bytesPerRow)!,
                                                   { releaseContext, baseAddress in


### PR DESCRIPTION
Fixed a bug in TVIScreenCapturer and in the software video pipeline where RGB CVPixelBuffer formats were incorrectly assumed to use host ordering (little endian on Ax ARM-based CPUs) instead of their in memory 