### PR TITLE
Consume 2.0.0-preview4.

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -4,7 +4,7 @@ workspace 'VideoQuickStart'
 platform :ios, '8.1'
 
 abstract_target 'TwilioVideo' do
-  pod 'TwilioVideo', '2.0.0-preview3'
+  pod 'TwilioVideo', '2.0.0-preview4'
 
   target 'VideoQuickStart' do
     project 'VideoQuickStart.xcproject'

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 # Twilio Video Quickstart for Swift
 
-> NOTE: These sample applications use the Twilio Video 2.0.0-preview3 APIs. We will continue to update them throughout the preview and beta period. For examples using our Generally Available 1.x APIs, please see the [master](https://github.com/twilio/video-quickstart-swift) branch.
+> NOTE: These sample applications use the Twilio Video 2.0.0-preview4 APIs. We will continue to update them throughout the preview and beta period. For examples using our Generally Available 1.x APIs, please see the [master](https://github.com/twilio/video-quickstart-swift) branch.
 
 Get started with Video on iOS:
 
@@ -117,7 +117,7 @@ For this Quickstart, the Application transport security settings are set to allo
 You can find more documentation on getting started as well as our latest Docs below:
 
 * [Getting Started](https://www.twilio.com/docs/api/video/getting-started)
-* [Docs](https://media.twiliocdn.com/sdk/ios/video/releases/2.0.0-preview3/docs)
+* [Docs](https://media.twiliocdn.com/sdk/ios/video/releases/2.0.0-preview4/docs)
 
 ## Issues and Support
 


### PR DESCRIPTION
No breaking API changes in areas covered by the examples, since stats is not covered.