### PR TITLE
Consuming 2.0.0 preview8

### DIFF
--- a/AudioSinkExample/ViewController.swift
+++ b/AudioSinkExample/ViewController.swift
@@ -664,6 +664,18 @@ extension ViewController : TVIRemoteParticipantDelegate {
         // We will continue to record silence and/or recognize audio while a Track is disabled.
         logMessage(messageText: "Participant \(participant.identity) disabled \(publication.trackName) audio track")
     }
+
+    func failedToSubscribe(toAudioTrack publication: TVIRemoteAudioTrackPublication,
+                           error: Error,
+                           for participant: TVIRemoteParticipant) {
+        logMessage(messageText: "FailedToSubscribe \(publication.trackName) audio track, error = \(String(describing: error))")
+    }
+
+    func failedToSubscribe(toVideoTrack publication: TVIRemoteVideoTrackPublication,
+                           error: Error,
+                           for participant: TVIRemoteParticipant) {
+        logMessage(messageText: "FailedToSubscribe \(publication.trackName) video track, error = \(String(describing: error))")
+    }
 }
 
 // MARK: TVILocalParticipantDelegate

--- a/DataTrackExample.xcodeproj/project.pbxproj
+++ b/DataTrackExample.xcodeproj/project.pbxproj
@@ -327,7 +327,7 @@
 					"$(PROJECT_DIR)",
 				);
 				INFOPLIST_FILE = DataTrackExample/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 8.1;
+				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = com.twilio.DataTrackExample;
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -347,7 +347,7 @@
 					"$(PROJECT_DIR)",
 				);
 				INFOPLIST_FILE = DataTrackExample/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 8.1;
+				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = com.twilio.DataTrackExample;
 				PRODUCT_NAME = "$(TARGET_NAME)";

--- a/DataTrackExample/ViewController.swift
+++ b/DataTrackExample/ViewController.swift
@@ -327,6 +327,12 @@ extension ViewController : TVIRemoteParticipantDelegate {
         self.removeDrawer(dataTrack)
         logMessage(messageText: "Unsubscribed from data track for Participant \(participant.identity)")
     }
+
+    func failedToSubscribe(toDataTrack publication: TVIRemoteDataTrackPublication,
+                           error: Error,
+                           for participant: TVIRemoteParticipant) {
+        logMessage(messageText: "FailedToSubscribe \(publication.trackName) data track, error = \(String(describing: error))")
+    }
 }
 
 // MARK: TVIRemoteDataTrackDelegate

--- a/Podfile
+++ b/Podfile
@@ -3,7 +3,7 @@ source 'https://github.com/CocoaPods/Specs'
 workspace 'VideoQuickStart'
 
 abstract_target 'TwilioVideo' do
-  pod 'TwilioVideo', '2.0.0-preview7'
+  pod 'TwilioVideo', '2.0.0-preview8'
 
   target 'ARKitExample' do
     platform :ios, '11.0'
@@ -16,7 +16,7 @@ abstract_target 'TwilioVideo' do
   end
 
   target 'VideoQuickStart' do
-    platform :ios, '8.1'
+    platform :ios, '9.0'
     project 'VideoQuickStart.xcproject'
   end
   
@@ -26,12 +26,12 @@ abstract_target 'TwilioVideo' do
   end
 
   target 'ScreenCapturerExample' do
-    platform :ios, '8.1'
+    platform :ios, '9.0'
     project 'ScreenCapturerExample.xcproject'
   end
 
   target 'DataTrackExample' do
-    platform :ios, '8.1'
+    platform :ios, '9.0'
     project 'DataTrackExample.xcproject'
   end
 

--- a/ScreenCapturerExample.xcodeproj/project.pbxproj
+++ b/ScreenCapturerExample.xcodeproj/project.pbxproj
@@ -295,7 +295,7 @@
 				CLANG_ENABLE_MODULES = YES;
 				DEVELOPMENT_TEAM = SX5J6BN2KX;
 				INFOPLIST_FILE = ScreenCapturerExample/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 8.1;
+				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = com.twilio.ScreenCapturerExample;
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -311,7 +311,7 @@
 				CLANG_ENABLE_MODULES = YES;
 				DEVELOPMENT_TEAM = SX5J6BN2KX;
 				INFOPLIST_FILE = ScreenCapturerExample/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 8.1;
+				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = com.twilio.ScreenCapturerExample;
 				PRODUCT_NAME = "$(TARGET_NAME)";

--- a/VideoCallKitQuickStart/ViewController+CallKit.swift
+++ b/VideoCallKitQuickStart/ViewController+CallKit.swift
@@ -205,12 +205,7 @@ extension ViewController {
             builder.audioTracks = self.localAudioTrack != nil ? [self.localAudioTrack!] : [TVILocalAudioTrack]()
             builder.videoTracks = self.localVideoTrack != nil ? [self.localVideoTrack!] : [TVILocalVideoTrack]()
 
-            /**
-             * Use the audio device. Please note that the SDK does not support the use of multiple audio devices at the
-             * same time. If you've already connected to a Room, then all future connection attempts must use the same
-             * TVIDefaultAudioDevice as the first Room. Once all the existing Rooms are disconnected you are free to
-             * choose a new audio device for your next connection attempt.
-             */
+            // Use the audio device that we created earlier. All connection attempts will use the same device.
             builder.audioDevice = self.audioDevice
             
             // Use the preferred audio codec

--- a/VideoCallKitQuickStart/ViewController+CallKit.swift
+++ b/VideoCallKitQuickStart/ViewController+CallKit.swift
@@ -93,7 +93,7 @@ extension ViewController : CXProviderDelegate {
         NSLog("provider:performEndCallAction:")
 
         // AudioDevice is enabled by default
-        self.audioDevice.isEnabled = true;
+        self.audioDevice.isEnabled = true
         room?.disconnect()
 
         action.fulfill()
@@ -205,7 +205,12 @@ extension ViewController {
             builder.audioTracks = self.localAudioTrack != nil ? [self.localAudioTrack!] : [TVILocalAudioTrack]()
             builder.videoTracks = self.localVideoTrack != nil ? [self.localVideoTrack!] : [TVILocalVideoTrack]()
 
-            // Use the audio device
+            /**
+             * Use the audio device. Please note that the SDK does not support the use of multiple audio devices at the
+             * same time. If you've already connected to a Room, then all future connection attempts must use the same
+             * TVIDefaultAudioDevice as the first Room. Once all the existing Rooms are disconnected you are free to
+             * choose a new audio device for your next connection attempt.
+             */
             builder.audioDevice = self.audioDevice
             
             // Use the preferred audio codec

--- a/VideoCallKitQuickStart/ViewController+CallKit.swift
+++ b/VideoCallKitQuickStart/ViewController+CallKit.swift
@@ -16,7 +16,9 @@ extension ViewController : CXProviderDelegate {
     func providerDidReset(_ provider: CXProvider) {
         logMessage(messageText: "providerDidReset:")
 
-        TVIAudioController.shared().stopAudio()
+        // AudioDevice is enabled by default
+        self.audioDevice.isEnabled = true
+        
         room?.disconnect()
     }
 
@@ -27,7 +29,7 @@ extension ViewController : CXProviderDelegate {
     func provider(_ provider: CXProvider, didActivate audioSession: AVAudioSession) {
         logMessage(messageText: "provider:didActivateAudioSession:")
 
-        TVIAudioController.shared().startAudio()
+        self.audioDevice.isEnabled = true
     }
 
     func provider(_ provider: CXProvider, didDeactivate audioSession: AVAudioSession) {
@@ -45,7 +47,12 @@ extension ViewController : CXProviderDelegate {
          * Configure the audio session, but do not start call audio here, since it must be done once
          * the audio session has been activated by the system after having its priority elevated.
          */
-        TVIAudioController.shared().configureAudioSession(.videoChatSpeaker)
+
+        // Stop the audio unit by setting isEnabled to `false`.
+        self.audioDevice.isEnabled = false;
+
+        // Configure the AVAudioSession by executign the audio device's `block`.
+        self.audioDevice.block()
 
         callKitProvider.reportOutgoingCall(with: action.callUUID, startedConnectingAt: nil)
         
@@ -66,7 +73,12 @@ extension ViewController : CXProviderDelegate {
          * Configure the audio session, but do not start call audio here, since it must be done once
          * the audio session has been activated by the system after having its priority elevated.
          */
-        TVIAudioController.shared().configureAudioSession(.videoChatSpeaker)
+
+        // Stop the audio unit by setting isEnabled to `false`.
+        self.audioDevice.isEnabled = false;
+
+        // Configure the AVAudioSession by executign the audio device's `block`.
+        self.audioDevice.block()
 
         performRoomConnect(uuid: action.callUUID, roomName: self.roomTextField.text) { (success) in
             if (success) {
@@ -80,7 +92,8 @@ extension ViewController : CXProviderDelegate {
     func provider(_ provider: CXProvider, perform action: CXEndCallAction) {
         NSLog("provider:performEndCallAction:")
 
-        TVIAudioController.shared().stopAudio()
+        // AudioDevice is enabled by default
+        self.audioDevice.isEnabled = true;
         room?.disconnect()
 
         action.fulfill()
@@ -191,6 +204,9 @@ extension ViewController {
             // Use the local media that we prepared earlier.
             builder.audioTracks = self.localAudioTrack != nil ? [self.localAudioTrack!] : [TVILocalAudioTrack]()
             builder.videoTracks = self.localVideoTrack != nil ? [self.localVideoTrack!] : [TVILocalVideoTrack]()
+
+            // Use the audio device
+            builder.audioDevice = self.audioDevice
             
             // Use the preferred audio codec
             if let preferredAudioCodec = Settings.shared.audioCodec {

--- a/VideoCallKitQuickStart/ViewController.swift
+++ b/VideoCallKitQuickStart/ViewController.swift
@@ -23,6 +23,12 @@ class ViewController: UIViewController {
     
     // Video SDK components
     var room: TVIRoom?
+    /**
+     * We will create an audio device and use it in Room. Please note that the SDK does not support the use of multiple
+     * audio devices at the same time. If you've already connected to a Room, then all future connection attempts must
+     * use the same TVIDefaultAudioDevice as the first Room. Once all the existing Rooms are disconnected you are free to
+     * choose a new audio device for your next connection attempt.
+     */
     var audioDevice: TVIDefaultAudioDevice = TVIDefaultAudioDevice()
     var camera: TVICameraCapturer?
     var localVideoTrack: TVILocalVideoTrack?
@@ -426,6 +432,18 @@ extension ViewController : TVIRemoteParticipantDelegate {
     func remoteParticipant(_ participant: TVIRemoteParticipant,
                            disabledAudioTrack publication: TVIRemoteAudioTrackPublication) {
         logMessage(messageText: "Participant \(participant.identity) disabled audio track")
+    }
+
+    func failedToSubscribe(toAudioTrack publication: TVIRemoteAudioTrackPublication,
+                           error: Error,
+                           for participant: TVIRemoteParticipant) {
+        logMessage(messageText: "FailedToSubscribe \(publication.trackName) audio track, error = \(String(describing: error))")
+    }
+
+    func failedToSubscribe(toVideoTrack publication: TVIRemoteVideoTrackPublication,
+                           error: Error,
+                           for participant: TVIRemoteParticipant) {
+        logMessage(messageText: "FailedToSubscribe \(publication.trackName) video track, error = \(String(describing: error))")
     }
 }
 

--- a/VideoCallKitQuickStart/ViewController.swift
+++ b/VideoCallKitQuickStart/ViewController.swift
@@ -23,6 +23,7 @@ class ViewController: UIViewController {
     
     // Video SDK components
     var room: TVIRoom?
+    var audioDevice: TVIDefaultAudioDevice = TVIDefaultAudioDevice()
     var camera: TVICameraCapturer?
     var localVideoTrack: TVILocalVideoTrack?
     var localAudioTrack: TVILocalAudioTrack?

--- a/VideoCallKitQuickStart/ViewController.swift
+++ b/VideoCallKitQuickStart/ViewController.swift
@@ -24,10 +24,10 @@ class ViewController: UIViewController {
     // Video SDK components
     var room: TVIRoom?
     /**
-     * We will create an audio device and use it in Room. Please note that the SDK does not support the use of multiple
-     * audio devices at the same time. If you've already connected to a Room, then all future connection attempts must
-     * use the same TVIDefaultAudioDevice as the first Room. Once all the existing Rooms are disconnected you are free to
-     * choose a new audio device for your next connection attempt.
+     * We will create an audio device and manage it's lifecycle in response to CallKit events. Please note that the SDK
+     * does not support the use of multiple audio devices at the same time. If you've already connected to a Room, then
+     * all future connection attempts must use the same TVIDefaultAudioDevice as the first Room. Once all the existing
+     * Rooms are disconnected you are free to choose a new audio device for your next connection attempt.
      */
     var audioDevice: TVIDefaultAudioDevice = TVIDefaultAudioDevice()
     var camera: TVICameraCapturer?

--- a/VideoQuickStart.xcodeproj/project.pbxproj
+++ b/VideoQuickStart.xcodeproj/project.pbxproj
@@ -362,10 +362,10 @@
 					"$(PROJECT_DIR)",
 				);
 				INFOPLIST_FILE = VideoQuickStart/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 8.1;
+				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				OTHER_LDFLAGS = "$(inherited)";
-				PRODUCT_BUNDLE_IDENTIFIER = com.twilio.VideoQuickStart;
+				PRODUCT_BUNDLE_IDENTIFIER = com.twilio.VideoQuickStart1;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_VERSION = 3.0;
 			};

--- a/VideoQuickStart/ViewController.swift
+++ b/VideoQuickStart/ViewController.swift
@@ -426,6 +426,14 @@ extension ViewController : TVIRemoteParticipantDelegate {
                            disabledAudioTrack publication: TVIRemoteAudioTrackPublication) {
         logMessage(messageText: "Participant \(participant.identity) disabled \(publication.trackName) audio track")
     }
+
+    func failedToSubscribe(toAudioTrack publication: TVIRemoteAudioTrackPublication, error: Error, for participant: TVIRemoteParticipant) {
+        logMessage(messageText: "FailedToSubscribe \(publication.trackName) audio track, error = \(String(describing: error))")
+    }
+
+    func failedToSubscribe(toVideoTrack publication: TVIRemoteVideoTrackPublication, error: Error, for participant: TVIRemoteParticipant) {
+        logMessage(messageText: "FailedToSubscribe \(publication.trackName) video track, error = \(String(describing: error))")
+    }
 }
 
 // MARK: TVIVideoViewDelegate

--- a/VideoQuickStart/ViewController.swift
+++ b/VideoQuickStart/ViewController.swift
@@ -427,11 +427,15 @@ extension ViewController : TVIRemoteParticipantDelegate {
         logMessage(messageText: "Participant \(participant.identity) disabled \(publication.trackName) audio track")
     }
 
-    func failedToSubscribe(toAudioTrack publication: TVIRemoteAudioTrackPublication, error: Error, for participant: TVIRemoteParticipant) {
+    func failedToSubscribe(toAudioTrack publication: TVIRemoteAudioTrackPublication,
+                           error: Error,
+                           for participant: TVIRemoteParticipant) {
         logMessage(messageText: "FailedToSubscribe \(publication.trackName) audio track, error = \(String(describing: error))")
     }
 
-    func failedToSubscribe(toVideoTrack publication: TVIRemoteVideoTrackPublication, error: Error, for participant: TVIRemoteParticipant) {
+    func failedToSubscribe(toVideoTrack publication: TVIRemoteVideoTrackPublication,
+                           error: Error,
+                           for participant: TVIRemoteParticipant) {
         logMessage(messageText: "FailedToSubscribe \(publication.trackName) video track, error = \(String(describing: error))")
     }
 }


### PR DESCRIPTION
Consuming TwilioVideo 2.0.0-preview8 -
1. Callkit sample app uses new `TVIDefaultAudioDevice`
2. Basic Quickstart logs error when subscription error occurs.
3. Deprecated 8.1 support.