### PR TITLE
ISDK-1912: Support TVIAudioDevice backgrounding (2.0.0-beta3)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,6 +45,9 @@ VideoQuickStart.xcworkspace
 
 Carthage/Build
 
+# Manual Install
+TwilioVideo.framework/
+
 # fastlane
 #
 # It is recommended to not store the screenshots in the git repo. Instead, use fastlane to re-generate the 

--- a/AudioDeviceExample/AudioDevices/ExampleAVAudioEngineDevice.m
+++ b/AudioDeviceExample/AudioDevices/ExampleAVAudioEngineDevice.m
@@ -856,6 +856,15 @@ static OSStatus ExampleAVAudioEngineDeviceRecordCallback(void *refCon,
             TVIAudioDeviceContext context = [self deviceContext];
             if (context) {
                 TVIAudioDeviceFormatChanged(context);
+
+                TVIAudioDeviceExecuteWorkerBlock(context, ^{
+                    // Restart the AVAudioEngine with new format
+                    TVIAudioFormat *activeFormat = [[self class] activeFormat];
+                    if (![activeFormat isEqual:_renderingFormat]) {
+                        [self teardownAudioEngine];
+                        [self setupAudioEngine];
+                    }
+                });
             }
         }
     }

--- a/AudioDeviceExample/AudioDevices/ExampleCoreAudioDevice.m
+++ b/AudioDeviceExample/AudioDevices/ExampleCoreAudioDevice.m
@@ -239,7 +239,8 @@ static OSStatus ExampleCoreAudioDevicePlayoutCallback(void *refCon,
         NSLog(@"Error setting sample rate: %@", error);
     }
 
-    if (![session setPreferredOutputNumberOfChannels:kPreferredNumberOfChannels error:&error]) {
+    NSInteger preferredOutputChannels = session.outputNumberOfChannels >= kPreferredNumberOfChannels ? kPreferredNumberOfChannels : session.outputNumberOfChannels;
+    if (![session setPreferredOutputNumberOfChannels:preferredOutputChannels error:&error]) {
         NSLog(@"Error setting number of output channels: %@", error);
     }
 

--- a/AudioDeviceExample/AudioDevices/ExampleCoreAudioDevice.m
+++ b/AudioDeviceExample/AudioDevices/ExampleCoreAudioDevice.m
@@ -127,16 +127,23 @@ static size_t kMaximumFramesPerBuffer = 1156;
             return NO;
         }
     }
-    return [self startAudioUnit];
+
+    BOOL success = [self startAudioUnit];
+    if (success) {
+        TVIAudioSessionActivated(context);
+    }
+    return success;
 }
 
 - (BOOL)stopRendering {
     [self stopAudioUnit];
 
     @synchronized(self) {
+        NSAssert(self.renderingContext != NULL, @"Should have a rendering context.");
+        TVIAudioSessionDeactivated(self.renderingContext->deviceContext);
+
         [self teardownAudioUnit];
 
-        NSAssert(self.renderingContext != NULL, @"Should have a rendering context.");
         free(self.renderingContext);
         self.renderingContext = NULL;
     }

--- a/AudioDeviceExample/README.md
+++ b/AudioDeviceExample/README.md
@@ -46,7 +46,3 @@ After the remote Participant has joined you should be able to hear their audio. 
 ### Known Issues
 
 The AVAudioSession is configured and activated at playback initialization time. Ideally, it would be better to activate the AVAudioSession only when audio playback is needed.
-
-You will also notice that backgrounding the application causes the signaling connection to die.
-
-Both issues are limitations with custom `TVIAudioDevice`s in [2.0.0-beta2](https://www.twilio.com/docs/api/video/changelog-twilio-video-ios-version-2x#200-beta2-february-27-2018) and we expect to rectify them in future releases.

--- a/AudioDeviceExample/README.md
+++ b/AudioDeviceExample/README.md
@@ -45,4 +45,4 @@ After the remote Participant has joined you should be able to hear their audio. 
 
 ### Known Issues
 
-The AVAudioSession is configured and activated at playback initialization time. Ideally, it would be better to activate the AVAudioSession only when audio playback is needed.
+The AVAudioSession is configured and activated at device initialization time. Ideally, it would be better to activate the AVAudioSession only when audio playback or recording is needed.

--- a/AudioDeviceExample/ViewController.swift
+++ b/AudioDeviceExample/ViewController.swift
@@ -364,7 +364,7 @@ class ViewController: UIViewController {
                 }
             }
         } else {
-            logMessage(messageText: "Front camera is not available, using audio playback only.")
+            logMessage(messageText: "Front camera is not available, using audio only.")
         }
     }
 

--- a/DataTrackExample/Info.plist
+++ b/DataTrackExample/Info.plist
@@ -2,6 +2,8 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>NSMicrophoneUsageDescription</key>
+	<string>${PRODUCT_NAME} does not use your microphone, but requires permission to play audio due to issue #207.</string>
 	<key>CFBundleDevelopmentRegion</key>
 	<string>$(DEVELOPMENT_LANGUAGE)</string>
 	<key>CFBundleExecutable</key>

--- a/Podfile
+++ b/Podfile
@@ -3,7 +3,7 @@ source 'https://github.com/CocoaPods/Specs'
 workspace 'VideoQuickStart'
 
 abstract_target 'TwilioVideo' do
-  pod 'TwilioVideo', '2.0.0-beta2'
+  pod 'TwilioVideo', '2.0.0-beta3'
 
   target 'ARKitExample' do
     platform :ios, '11.0'

--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
 
 [ ![Download](https://img.shields.io/badge/Download-iOS%20SDK-blue.svg) ](https://www.twilio.com/docs/api/video/download-video-sdks#ios-sdk)
-[![Docs](https://img.shields.io/badge/iOS%20Docs-OK-blue.svg)](https://media.twiliocdn.com/sdk/ios/video/releases/2.0.0-beta2/docs/index.html)
+[![Docs](https://img.shields.io/badge/iOS%20Docs-OK-blue.svg)](https://media.twiliocdn.com/sdk/ios/video/releases/2.0.0-beta3/docs/index.html)
 
 # Twilio Video Quickstart for Swift
 
-> NOTE: These sample applications use the Twilio Video 2.0.0-beta2 APIs. We will continue to update them throughout the beta period. For examples using our Generally Available 1.x APIs, please see the [1.x](https://github.com/twilio/video-quickstart-swift/tree/1.x) branch.
+> NOTE: These sample applications use the Twilio Video 2.0.0-beta3 APIs. We will continue to update them throughout the beta period. For examples using our Generally Available 1.x APIs, please see the [1.x](https://github.com/twilio/video-quickstart-swift/tree/1.x) branch.
 
 Get started with Video on iOS:
 
@@ -121,7 +121,7 @@ For this Quickstart, the Application transport security settings are set to allo
 You can find more documentation on getting started as well as our latest Docs below:
 
 * [Getting Started](https://www.twilio.com/docs/api/video/getting-started)
-* [Docs](https://media.twiliocdn.com/sdk/ios/video/releases/2.0.0-beta2/docs)
+* [Docs](https://media.twiliocdn.com/sdk/ios/video/releases/2.0.0-beta3/docs)
 
 ## Issues and Support
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 
 [ ![Download](https://img.shields.io/badge/Download-iOS%20SDK-blue.svg) ](https://www.twilio.com/docs/api/video/download-video-sdks#ios-sdk)
-[![Docs](https://img.shields.io/badge/iOS%20Docs-OK-blue.svg)](https://media.twiliocdn.com/sdk/ios/video/releases/2.0.0-beta3/docs/index.html)
+[![Docs](https://img.shields.io/badge/iOS%20Docs-OK-blue.svg)](https://twilio.github.io/twilio-video-ios/docs/2.0.0-beta3/index.html)
 
 # Twilio Video Quickstart for Swift
 
@@ -121,7 +121,7 @@ For this Quickstart, the Application transport security settings are set to allo
 You can find more documentation on getting started as well as our latest Docs below:
 
 * [Getting Started](https://www.twilio.com/docs/api/video/getting-started)
-* [Docs](https://media.twiliocdn.com/sdk/ios/video/releases/2.0.0-beta3/docs)
+* [Docs](https://twilio.github.io/twilio-video-ios/docs/2.0.0-beta3/index.html)
 
 ## Issues and Support
 


### PR DESCRIPTION
### Description

This PR adds support for the API changes in 2.0.0-beta3, focusing on TVIAudioDevice and backgrounding. The devices in AudioDeviceExample have been updated to signal AVAudioSession state changes. I also updated the READMEs, and Podspec.

### Discussion

Right now, our examples are "static" in their usage of AVAudioSession and they typically just activate it at initialization time (`ExampleAVAudioEngineDevice`) or when the first format is read (`ExampleCoreAudioDevice`). 

I followed the convention from @piyushtank's original commit, by firing audio session events after starting/stopping the AudioUnit. I think we should reconsider this approach and tie the events purely to AVAudioSession interruptions, and manually activating / deactivating the AVAudioSession. This would make the code easier to read, and a truer representation of the AVAudioSession state.

### Testing

So far I've been testing on iOS 11.2.6 but I'll give this a try on a few more device / OS combos before we merge the changes tomorrow.