### PR TITLE
ISDK-1989: Update for 2.0.0 APIs

### DIFF
--- a/ARKitExample/ViewController.swift
+++ b/ARKitExample/ViewController.swift
@@ -77,7 +77,7 @@ class ViewController: UIViewController {
         // Release any cached data, images, etc that aren't in use.
     }
 
-    @objc func displayLinkDidFire() {
+    @objc func displayLinkDidFire(timer: CADisplayLink) {
         // Our capturer polls the ARSCNView's snapshot for processed AR video content, and then copies the result into a CVPixelBuffer.
         // This process is not ideal, but it is the most straightforward way to capture the output of SceneKit.
         let myImage = self.sceneView.snapshot
@@ -88,7 +88,7 @@ class ViewController: UIViewController {
 
         // As a TVIVideoCapturer, we must deliver CVPixelBuffers and not CGImages to the consumer.
         if let pixelBuffer = self.copyPixelbufferFromCGImageProvider(image: imageRef) {
-            self.frame = TVIVideoFrame(timestamp: Int64((displayLink?.timestamp)! * 1000000),
+            self.frame = TVIVideoFrame(timeInterval: timer.timestamp,
                                        buffer: pixelBuffer,
                                        orientation: TVIVideoOrientation.up)
             self.consumer?.consumeCapturedFrame(self.frame!)

--- a/Podfile
+++ b/Podfile
@@ -3,7 +3,7 @@ source 'https://github.com/CocoaPods/Specs'
 workspace 'VideoQuickStart'
 
 abstract_target 'TwilioVideo' do
-  pod 'TwilioVideo', '2.0.0-beta4'
+  pod 'TwilioVideo', '~> 2.0.0'
 
   target 'ARKitExample' do
     platform :ios, '11.0'

--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
 
 [ ![Download](https://img.shields.io/badge/Download-iOS%20SDK-blue.svg) ](https://www.twilio.com/docs/api/video/download-video-sdks#ios-sdk)
-[![Docs](https://img.shields.io/badge/iOS%20Docs-OK-blue.svg)](https://twilio.github.io/twilio-video-ios/docs/2.0.0-beta4/index.html)
+[![Docs](https://img.shields.io/badge/iOS%20Docs-OK-blue.svg)](https://twilio.github.io/twilio-video-ios/docs/latest/index.html)
 
 # Twilio Video Quickstart for Swift
 
-> NOTE: These sample applications use the Twilio Video 2.0.0-beta4 APIs. We will continue to update them throughout the beta period. For examples using our Generally Available 1.x APIs, please see the [1.x](https://github.com/twilio/video-quickstart-swift/tree/1.x) branch.
+> NOTE: These sample applications use the Twilio Video 2.x APIs. For examples using our 1.x APIs, please see the [1.x](https://github.com/twilio/video-quickstart-swift/tree/1.x) branch.
 
 Get started with Video on iOS:
 
@@ -121,7 +121,7 @@ For this Quickstart, the Application transport security settings are set to allo
 You can find more documentation on getting started as well as our latest Docs below:
 
 * [Getting Started](https://www.twilio.com/docs/api/video/getting-started)
-* [Docs](https://twilio.github.io/twilio-video-ios/docs/2.0.0-beta4/index.html)
+* [Docs](https://twilio.github.io/twilio-video-ios/docs/latest/index.html)
 
 ## Issues and Support
 

--- a/ScreenCapturerExample/ExampleScreenCapturer.swift
+++ b/ScreenCapturerExample/ExampleScreenCapturer.swift
@@ -157,18 +157,16 @@ class ExampleScreenCapturer: NSObject, TVIVideoCapturer {
                                                   nil,
                                                   &pixelBuffer)
 
-        if (status != kCVReturnSuccess) {
-            return;
+        if let buffer = pixelBuffer {
+            // Deliver a frame to the consumer. Images drawn by UIGraphics do not need any rotation tags.
+            let frame = TVIVideoFrame(timeInterval: timer.timestamp,
+                                      buffer: buffer,
+                                      orientation: TVIVideoOrientation.up)
+
+            // The consumer retains the CVPixelBuffer and will own it as the buffer flows through the video pipeline.
+            captureConsumer?.consumeCapturedFrame(frame!)
+        } else {
+            print("Capture failed with status code: \(status).")
         }
-
-        // Deliver a VideoFrame to the consumer. Images drawn by UIGraphics do not need any rotation tags.
-        // Express timestamps in microseconds
-        let timeStamp = Int64(timer.timestamp * Double( 1000000 ))
-        let frame = TVIVideoFrame(timestamp: timeStamp,
-                                  buffer: pixelBuffer!,
-                                  orientation: TVIVideoOrientation.up)
-
-        // The consumer retains the CVPixelBuffer and will own it as the buffer flows through the video pipeline.
-        captureConsumer?.consumeCapturedFrame(frame!)
     }
 }


### PR DESCRIPTION
Update our example apps for the 2.0.0 APIs. Since we don't reuse TVIVideoView this means that the changes were limited to TVIVideoFrame initialization.

I also updated the README.md and Podfile while I was at it.
