### PR TITLE
ISDK-1995: Fix parsing crash in DataTrackExample.

### DIFF
--- a/DataTrackExample/ViewController.swift
+++ b/DataTrackExample/ViewController.swift
@@ -356,12 +356,12 @@ extension ViewController : TVIRemoteDataTrackDelegate {
             if let jsonDictionary = try JSONSerialization.jsonObject(with: message, options: []) as? [String: AnyObject] {
                 NSLog("processJsonData: \(jsonDictionary)" )
                 
-                if let touch = jsonDictionary[self.kTouchPoint] as? [String: AnyObject] {
-                    let pointX = touch[self.kXCoordinate] as! Float
-                    let pointY = touch[self.kYCoordinate] as! Float
+                if let touch = jsonDictionary[self.kTouchPoint] as? [String: AnyObject],
+                    let pointX = touch[self.kXCoordinate] as? NSNumber,
+                    let pointY = touch[self.kYCoordinate] as? NSNumber {
                     
-                    let theTouchPoint = CGPoint(x: CGFloat(pointX) * self.view.bounds.width,
-                                                y: CGFloat(pointY) * self.view.bounds.height)
+                    let theTouchPoint = CGPoint(x: CGFloat(pointX.floatValue) * self.view.bounds.width,
+                                                y: CGFloat(pointY.floatValue) * self.view.bounds.height)
                     
                     if let touchBegan = jsonDictionary[self.kTouchBegan] {
                         if (touchBegan).boolValue {
@@ -372,6 +372,8 @@ extension ViewController : TVIRemoteDataTrackDelegate {
                         }
                         success = true
                     }
+                } else {
+                    print("Unable to parse incoming JSON data. \(jsonDictionary)")
                 }
             }
             if success == false {


### PR DESCRIPTION
This is similar to the fix made in our internal demo app, but hopefully a little more Swifty. In some cases, its not possible to cast the parsed JSON payload's members directly to a Float. See the ticket and internal PR for more info.