### PR TITLE
ISDK-2197: Add a README.md for ScreenCapturerExample.

### DIFF
--- a/ScreenCapturerExample/README.md
+++ b/ScreenCapturerExample/README.md
@@ -1,0 +1,11 @@
+# Twilio Video ScreenCapturer Example
+
+> NOTE: `TVIScreenCapturer` is deprecated on iOS 12.0 and above due to performance issues on wide-color devices. If you wish to share the contents of the screen we recommend that you use [ReplayKit](https://developer.apple.com/documentation/replaykit) instead. We are currently working on a ReplayKit example [app](https://github.com/twilio/video-quickstart-swift/pull/287).
+
+This project demonstrates how to use `TVIScreenCapturer`, or a custom class (`ExampleScreenCapturer`) to capture the contents of a `UIView`. In this case, we are targeting a `WKWebView`, but the approach is suitably generic to work with any `UIView`.
+
+### Setup
+
+See the master [README](https://github.com/twilio/video-quickstart-swift/blob/master/README.md) for instructions on how to generate access tokens and connect to a Room.
+
+This example requires a device running iOS 9.0 or above.

--- a/ScreenCapturerExample/README.md
+++ b/ScreenCapturerExample/README.md
@@ -6,6 +6,4 @@ This project demonstrates how to use `TVIScreenCapturer`, or a custom class (`Ex
 
 ### Setup
 
-See the master [README](https://github.com/twilio/video-quickstart-swift/blob/master/README.md) for instructions on how to generate access tokens and connect to a Room.
-
-This example requires a device running iOS 9.0 or above.
+This example does not connect to a Room, and thus does not require any access tokens or other configuration. Any device or simulator which supports iOS 9.0 or later may be used.

--- a/ScreenCapturerExample/README.md
+++ b/ScreenCapturerExample/README.md
@@ -6,4 +6,4 @@ This project demonstrates how to use `TVIScreenCapturer`, or a custom class (`Ex
 
 ### Setup
 
-This example does not connect to a Room, and thus does not require any access tokens or other configuration. Any device or simulator which supports iOS 9.0 or later may be used.
+This example does not connect to a Room, and thus does not require any access tokens or other configuration. Internet connectivity is required to load the contents of the `WKWebView`. Any device or simulator with iOS 9.0 or later may be used.


### PR DESCRIPTION
Includes a deprecation notice for `TVIScreenCapturer`.

I did not mention the deprecation in the master `README.md`. Should I? Clicking on the project link will now take you to the new `README.md` with the notice.