### PR TITLE
ISDK-2223: ReplayKit: Preallocate scaling buffers, fix leak.

### DIFF
--- a/ReplayKitExample/README.md
+++ b/ReplayKitExample/README.md
@@ -51,11 +51,13 @@ Tapping "Start Conference" begins capturing and sharing the screen from within t
 ### Betterments
 
 1. Use a faster resizing filter than Lancoz3. We spend a lot of CPU cycles resizing buffers from ReplayKit.
-2. Pre-allocate temporary buffers needed for `vImageScale` methods, or use `vImageVerticalShear` methods directly.
-3. Use a `CVPixelBufferPool` to constrain memory usage and to improve buffer reuse (fewer `CVPixelBuffer` allocations).
-4. Preserve color tags when downscaling `CVPixelBuffer`s.
-5. Support capturing both application and microphone audio at the same time, in an extension. Down-mix the resulting audio samples into a single stream.
-6. Share the camera using ReplayKit (extension), or `TVIVideoCapturer` (in-process).
+2. Use a `CVPixelBufferPool` to constrain memory usage and to improve buffer reuse (fewer `CVPixelBuffer` allocations).
+3. Preserve color tags when downscaling `CVPixelBuffer`s.
+4. Support capturing both application and microphone audio at the same time, in an extension. Down-mix the resulting audio samples into a single stream.
+5. Share the camera using ReplayKit (extension), or `TVIVideoCapturer` (in-process).
+6. Resolve tearing issues when scrolling vertically.
+7. Retransmit the last frame periodically when no more frames are coming from ReplayKit.
+8. Quantize ReplayKit video timestamps and use them to drop from 60 / 120 fps peaks to a lower rate (15 / 30).
 
 ### Known Issues
 

--- a/ReplayKitExample/ReplayKitExample/ReplayKitVideoSource.swift
+++ b/ReplayKitExample/ReplayKitExample/ReplayKitVideoSource.swift
@@ -74,6 +74,19 @@ class ReplayKitVideoSource: NSObject, TVIVideoCapturer {
         }
     }
 
+    deinit {
+        if let yBuffer = downscaleYPlaneBuffer {
+            free(yBuffer)
+            downscaleYPlaneBuffer = nil
+            downscaleYPlaneSize = 0
+        }
+        if let uvBuffer = downscaleUVPlaneBuffer {
+            free(uvBuffer)
+            downscaleUVPlaneBuffer = nil
+            downscaleUVPlaneSize = 0
+        }
+    }
+
     func startCapture(_ format: TVIVideoFormat, consumer: TVIVideoCaptureConsumer) {
         captureConsumer = consumer
 
@@ -87,16 +100,7 @@ class ReplayKitVideoSource: NSObject, TVIVideoCapturer {
     }
 
     func stopCapture() {
-        if let yBuffer = downscaleYPlaneBuffer {
-            free(yBuffer)
-            downscaleYPlaneBuffer = nil
-            downscaleYPlaneSize = 0
-        }
-        if let uvBuffer = downscaleUVPlaneBuffer {
-            free(uvBuffer)
-            downscaleUVPlaneBuffer = nil
-            downscaleUVPlaneSize = 0
-        }
+        captureConsumer = nil
         print("Stop capturing.")
     }
 

--- a/ReplayKitExample/ReplayKitExample/ViewController.swift
+++ b/ReplayKitExample/ReplayKitExample/ViewController.swift
@@ -224,6 +224,8 @@ class ViewController: UIViewController, RPBroadcastActivityViewControllerDelegat
 
         if self.screenTrack != nil {
             stopConference(error: error)
+        } else {
+            conferenceRoom = nil
         }
     }
 


### PR DESCRIPTION
This PR addresses some of the betterments identified in the original example [PR](https://github.com/twilio/video-quickstart-swift/pull/287).

We now preallocate and reuse the scaling buffers need for the `vImageScale` methods. This reduces our transient memory allocations. At the same time I noticed a bug where  we were holding on to the Room (and thus capturer) after disconnecting without an error.

**Before: Temporary vImage allocations**

<img width="878" alt="screen shot 2018-10-07 at 3 57 18 pm" src="https://user-images.githubusercontent.com/1302577/46588097-442da480-ca4b-11e8-85b8-5e0515bc6751.png">

**After: Only CVPixelBuffer allocations**

<img width="883" alt="screen shot 2018-10-07 at 3 32 34 pm" src="https://user-images.githubusercontent.com/1302577/46588099-498aef00-ca4b-11e8-8c22-9e46553d0887.png">