### PR TITLE
ISDK-2261: Properly handle non-user initiated room disconnections.

### DIFF
--- a/VideoCallKitQuickStart/ViewController.swift
+++ b/VideoCallKitQuickStart/ViewController.swift
@@ -312,8 +312,14 @@ extension ViewController : TVIRoomDelegate {
     func room(_ room: TVIRoom, didDisconnectWithError error: Error?) {
         logMessage(messageText: "Disconncted from room \(room.name), error = \(String(describing: error))")
 
-        if !self.userInitiatedDisconnect, let uuid = room.uuid {
-            self.callKitProvider.reportCall(with: uuid, endedAt: nil, reason: .failed)
+        if !self.userInitiatedDisconnect, let uuid = room.uuid, let error = error {
+            var reason = CXCallEndedReason.remoteEnded
+
+            if (error as NSError).code != TVIError.roomRoomCompletedError.rawValue {
+                reason = .failed
+            }
+
+            self.callKitProvider.reportCall(with: uuid, endedAt: nil, reason: reason)
         }
 
         self.cleanupRemoteParticipant()

--- a/VideoCallKitQuickStart/ViewController.swift
+++ b/VideoCallKitQuickStart/ViewController.swift
@@ -37,6 +37,7 @@ class ViewController: UIViewController {
     let callKitProvider: CXProvider
     let callKitCallController: CXCallController
     var callKitCompletionHandler: ((Bool)->Swift.Void?)? = nil
+    var userInitiatedDisconnect: Bool = false
 
     // MARK: UI Element Outlets and handles
     @IBOutlet weak var connectButton: UIButton!
@@ -160,6 +161,7 @@ class ViewController: UIViewController {
     @IBAction func disconnect(sender: AnyObject) {
         if let room = room, let uuid = room.uuid {
             logMessage(messageText: "Attempting to disconnect from room \(room.name)")
+            userInitiatedDisconnect = true
             performEndCallAction(uuid: uuid)
         }
     }
@@ -309,11 +311,16 @@ extension ViewController : TVIRoomDelegate {
     
     func room(_ room: TVIRoom, didDisconnectWithError error: Error?) {
         logMessage(messageText: "Disconncted from room \(room.name), error = \(String(describing: error))")
-        
+
+        if !self.userInitiatedDisconnect, let uuid = room.uuid {
+            self.callKitProvider.reportCall(with: uuid, endedAt: nil, reason: .failed)
+        }
+
         self.cleanupRemoteParticipant()
         self.room = nil
         self.showRoomUI(inRoom: false)
         self.callKitCompletionHandler = nil
+        self.userInitiatedDisconnect = false
     }
     
     func room(_ room: TVIRoom, didFailToConnectWithError error: Error) {


### PR DESCRIPTION
A customer reported an [issue](https://github.com/twilio/twilio-video-ios/issues/29) where the signaling connection timed out while in a room and on the CallKit UI from the lock screen and the CallKit UI never informed the user of the error.

Looking at the code, we were alerting CallKit that we were ending the call when it was initiated by the user, but were never doing anything if the call was ended from the server.

We now maintain a bit of state that lets us know if the user initiated the disconnect, and if not, we inform CallKit that the call has failed.

![screen shot 2018-11-09 at 4 54 16 pm](https://user-images.githubusercontent.com/25950/48290245-2c797f80-e440-11e8-849c-82cf56d82ac0.png)

![screen shot 2018-11-09 at 4 54 21 pm](https://user-images.githubusercontent.com/25950/48290255-3307f700-e440-11e8-9fcf-1a9d1dd2fb35.png)
