### PR TITLE
ISDK-2255: Use TVIVideoSource in the ReplayKitExample

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -3,7 +3,7 @@ source 'https://github.com/CocoaPods/Specs'
 workspace 'VideoQuickStart'
 
 abstract_target 'TwilioVideo' do
-  pod 'TwilioVideo', '~> 2.6'
+  pod 'TwilioVideo', '2.6.0-preview1'
 
   target 'ARKitExample' do
     platform :ios, '11.0'

--- a/Podfile
+++ b/Podfile
@@ -3,7 +3,7 @@ source 'https://github.com/CocoaPods/Specs'
 workspace 'VideoQuickStart'
 
 abstract_target 'TwilioVideo' do
-  pod 'TwilioVideo', '~> 2.5'
+  pod 'TwilioVideo', '~> 2.6'
 
   target 'ARKitExample' do
     platform :ios, '11.0'

--- a/ReplayKitExample/BroadcastExtension/SampleHandler.swift
+++ b/ReplayKitExample/BroadcastExtension/SampleHandler.swift
@@ -36,10 +36,28 @@ class SampleHandler: RPBroadcastSampleHandler, TVIRoomDelegate {
         }
 
         // This source will attempt to produce smaller buffers with fluid motion.
+        let outputFormat = TVIVideoFormat()
+
+        var screenSize = UIScreen.main.bounds.size
+        screenSize.width *= UIScreen.main.nativeScale
+        screenSize.height *= UIScreen.main.nativeScale
+
+        var adjustedSize: CGSize
+
+        if screenSize.height > screenSize.width {
+            adjustedSize = CGSize(width: 640 * screenSize.width / screenSize.height, height: 640)
+        } else {
+            adjustedSize = CGSize(width: 640, height: 640 * screenSize.height / screenSize.width)
+        }
+
+        outputFormat.dimensions = CMVideoDimensions(width: Int32(adjustedSize.width), height: Int32(adjustedSize.height))
+
         videoSource = ReplayKitVideoSource(isScreencast: false)
         screenTrack = TVILocalVideoTrack(source: videoSource!,
                                          enabled: true,
                                          name: "Screen")
+
+        videoSource!.requestOutputFormat(outputFormat)
 
         let localAudioTrack = TVILocalAudioTrack()
         let connectOptions = TVIConnectOptions(token: accessToken) { (builder) in

--- a/ReplayKitExample/BroadcastExtension/SampleHandler.swift
+++ b/ReplayKitExample/BroadcastExtension/SampleHandler.swift
@@ -37,13 +37,8 @@ class SampleHandler: RPBroadcastSampleHandler, TVIRoomDelegate {
 
         // This source will attempt to produce smaller buffers with fluid motion.
         videoSource = ReplayKitVideoSource(isScreencast: false)
-        let constraints = TVIVideoConstraints.init { (builder) in
-            builder.maxSize = CMVideoDimensions(width: Int32(ReplayKitVideoSource.kDownScaledMaxWidthOrHeight),
-                                                height: Int32(ReplayKitVideoSource.kDownScaledMaxWidthOrHeight))
-        }
-        screenTrack = TVILocalVideoTrack(capturer: videoSource!,
+        screenTrack = TVILocalVideoTrack(source: videoSource!,
                                          enabled: true,
-                                         constraints: constraints,
                                          name: "Screen")
 
         let localAudioTrack = TVILocalAudioTrack()

--- a/ReplayKitExample/ReplayKitExample/ReplayKitVideoSource.swift
+++ b/ReplayKitExample/ReplayKitExample/ReplayKitVideoSource.swift
@@ -119,7 +119,10 @@ class ReplayKitVideoSource: NSObject, TVIVideoSource {
                 = ReplayKitVideoSource.imageOrientationToVideoOrientation(imageOrientation: CGImagePropertyOrientation(rawValue: coreSampleOrientation)!)
         }
 
-        // Return the original pixel buffer without downscaling.
+        /*
+         * Return the original pixel buffer without any downscaling or cropping applied.
+         * You may use a format request to crop and/or scale the buffers produced by this class.
+         */
         deliverFrame(to: sink,
                      timestamp: CMSampleBufferGetPresentationTimeStamp(sampleBuffer),
                      buffer: sourcePixelBuffer,

--- a/ReplayKitExample/ReplayKitExample/ViewController.swift
+++ b/ReplayKitExample/ReplayKitExample/ViewController.swift
@@ -328,23 +328,8 @@ class ViewController: UIViewController, RPBroadcastActivityViewControllerDelegat
 
         // Our source produces either downscaled buffers with smoother motion, or an HD screen recording.
         videoSource = ReplayKitVideoSource(isScreencast: !ViewController.kDownscaleBuffers)
-        let constraints = TVIVideoConstraints.init { (builder) in
-            if (ViewController.kDownscaleBuffers) {
-                builder.maxSize = CMVideoDimensions(width: Int32(ReplayKitVideoSource.kDownScaledMaxWidthOrHeight),
-                                                    height: Int32(ReplayKitVideoSource.kDownScaledMaxWidthOrHeight))
-            } else {
-                builder.minSize = CMVideoDimensions(width: Int32(ReplayKitVideoSource.kDownScaledMaxWidthOrHeight + 1),
-                                                    height: Int32(ReplayKitVideoSource.kDownScaledMaxWidthOrHeight + 1))
-                var screenSize = UIScreen.main.bounds.size
-                screenSize.width *= UIScreen.main.nativeScale
-                screenSize.height *= UIScreen.main.nativeScale
-                builder.maxSize = CMVideoDimensions(width: Int32(screenSize.width),
-                                                    height: Int32(screenSize.height))
-            }
-        }
-        screenTrack = TVILocalVideoTrack(capturer: videoSource!,
+        screenTrack = TVILocalVideoTrack(source: videoSource!,
                                          enabled: true,
-                                         constraints: constraints,
                                          name: "Screen")
 
         recorder.startCapture(handler: { (sampleBuffer, type, error) in


### PR DESCRIPTION
This PR uses the `TVIVideoSource` APIs which will be part of the upcoming `2.6.0` release.

WIP