### PR TITLE
ISDK-2258 ARKit Example uses VideoSource APIs

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -3,7 +3,7 @@ source 'https://github.com/CocoaPods/Specs'
 workspace 'VideoQuickStart'
 
 abstract_target 'TwilioVideo' do
-  pod 'TwilioVideo', '2.6.0-preview2'
+  pod 'TwilioVideo', '~> 2.6'
 
   target 'ARKitExample' do
     platform :ios, '11.0'

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 # Twilio Video Quickstart for Swift
 
-> NOTE: These sample applications use the Twilio Video 2.x APIs. For examples using our Generally Available 1.x APIs, please see the [1.x](https://github.com/twilio/video-quickstart-swift/tree/1.x) branch.
+> NOTE: These sample applications use the Twilio Video 2.x APIs. Please see the [1.x](https://github.com/twilio/video-quickstart-swift/tree/1.x) branch for 1.x APIs.
 
 Get started with Video on iOS:
 

--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
 
 [ ![Download](https://img.shields.io/badge/Download-iOS%20SDK-blue.svg) ](https://www.twilio.com/docs/video/ios#add-the-sdk)
-[![Docs](https://img.shields.io/badge/iOS%20Docs-OK-blue.svg)](https://twilio.github.io/twilio-video-ios/docs/2.6.0-preview2/index.html)
+[![Docs](https://img.shields.io/badge/iOS%20Docs-OK-blue.svg)](https://twilio.github.io/twilio-video-ios/docs/2.6.0/index.html)
 
 # Twilio Video Quickstart for Swift
 
-> NOTE: These sample applications use the Twilio Video 2.6.0-preview APIs. For examples using our Generally Available 2.x APIs, please see the [master](https://github.com/twilio/video-quickstart-swift/tree/master) branch, and for 1.x APIs see the [1.x](https://github.com/twilio/video-quickstart-swift/tree/1.x) branch.
+> NOTE: These sample applications use the Twilio Video 2.x APIs. For examples using our Generally Available 1.x APIs, please see the [1.x](https://github.com/twilio/video-quickstart-swift/tree/1.x) branch.
 
 Get started with Video on iOS:
 
@@ -122,7 +122,7 @@ For this Quickstart, the Application transport security settings are set to allo
 You can find more documentation on getting started as well as our latest Docs below:
 
 * [Getting Started](https://www.twilio.com/docs/video/ios-v2-getting-started)
-* [Docs](https://twilio.github.io/twilio-video-ios/docs/2.6.0-preview2/index.html)
+* [Docs](https://twilio.github.io/twilio-video-ios/docs/2.6.0/index.html)
 
 ## Issues and Support
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 # Twilio Video Quickstart for Swift
 
-> NOTE: These sample applications use the Twilio Video 2.x APIs. Please see the [1.x](https://github.com/twilio/video-quickstart-swift/tree/1.x) branch for 1.x APIs.
+> NOTE: These sample applications use the Twilio Video 2.x APIs. For examples using our 1.x APIs, please see the [1.x](https://github.com/twilio/video-quickstart-swift/tree/1.x) branch.
 
 Get started with Video on iOS:
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 
 [ ![Download](https://img.shields.io/badge/Download-iOS%20SDK-blue.svg) ](https://www.twilio.com/docs/video/ios#add-the-sdk)
-[![Docs](https://img.shields.io/badge/iOS%20Docs-OK-blue.svg)](https://twilio.github.io/twilio-video-ios/docs/2.6.0/index.html)
+[![Docs](https://img.shields.io/badge/iOS%20Docs-OK-blue.svg)](https://twilio.github.io/twilio-video-ios/docs/latest/index.html)
 
 # Twilio Video Quickstart for Swift
 
@@ -122,7 +122,7 @@ For this Quickstart, the Application transport security settings are set to allo
 You can find more documentation on getting started as well as our latest Docs below:
 
 * [Getting Started](https://www.twilio.com/docs/video/ios-v2-getting-started)
-* [Docs](https://twilio.github.io/twilio-video-ios/docs/2.6.0/index.html)
+* [Docs](https://twilio.github.io/twilio-video-ios/docs/latest/index.html)
 
 ## Issues and Support
 


### PR DESCRIPTION
This PR has - 
- ARKit example uses VideoSource APIs
- Podfile updated to use 2.6
- README changes