### PR TITLE
Fix issue where CallKit mute states are out of sync between CallKit UI and App UI

### DIFF
--- a/VideoCallKitQuickStart/ViewController+CallKit.swift
+++ b/VideoCallKitQuickStart/ViewController+CallKit.swift
@@ -102,7 +102,7 @@ extension ViewController : CXProviderDelegate {
     func provider(_ provider: CXProvider, perform action: CXSetMutedCallAction) {
         NSLog("provier:performSetMutedCallAction:")
         
-        toggleMic(sender: self)
+        muteAudio(isMuted: action.isMuted)
         
         action.fulfill()
     }

--- a/VideoCallKitQuickStart/ViewController.swift
+++ b/VideoCallKitQuickStart/ViewController.swift
@@ -174,10 +174,10 @@ class ViewController: UIViewController {
 
             callKitCallController.request(transaction)  { error in
                 if let error = error {
-                    NSLog("SetMutedCallAction transaction request failed: \(error.localizedDescription)")
+                    self.logMessage(messageText: "SetMutedCallAction transaction request failed: \(error.localizedDescription)")
                     return
                 }
-                NSLog("SetMutedCallAction transaction request successful")
+                self.logMessage(messageText: "SetMutedCallAction transaction request successful")
             }
         }
     }

--- a/VideoCallKitQuickStart/ViewController.swift
+++ b/VideoCallKitQuickStart/ViewController.swift
@@ -167,11 +167,27 @@ class ViewController: UIViewController {
     }
     
     @IBAction func toggleMic(sender: AnyObject) {
-        if (self.localAudioTrack != nil) {
-            self.localAudioTrack?.isEnabled = !(self.localAudioTrack?.isEnabled)!
-            
+        if let room = room, let uuid = room.uuid, let localAudioTrack = self.localAudioTrack {
+            let isMuted = localAudioTrack.isEnabled
+            let muteAction = CXSetMutedCallAction(call: uuid, muted: isMuted)
+            let transaction = CXTransaction(action: muteAction)
+
+            callKitCallController.request(transaction)  { error in
+                if let error = error {
+                    NSLog("SetMutedCallAction transaction request failed: \(error.localizedDescription)")
+                    return
+                }
+                NSLog("SetMutedCallAction transaction request successful")
+            }
+        }
+    }
+
+    func muteAudio(isMuted: Bool) {
+        if let localAudioTrack = self.localAudioTrack {
+            localAudioTrack.isEnabled = !isMuted
+
             // Update the button title
-            if (self.localAudioTrack?.isEnabled == true) {
+            if (!isMuted) {
                 self.micButton.setTitle("Mute", for: .normal)
             } else {
                 self.micButton.setTitle("Unmute", for: .normal)


### PR DESCRIPTION
As reported in #351, the mute/unmute indicators between the CallKit UI and the AppUI were not always properly in sync. If muting/unmuting were performed from the CallKit UI, the AppUI would show the correct state on the button. However, if muting/unmuting from the AppUI, the CallKit UI would not be updated.

The issue was that we were never alerting the CallKitProvider about the change in mute status, which was an oversight. Now when the AppUI mute/button is pressed, a `CXSetMutedCallAction` object is created, wrapped in a `CXTransaction ` and is given to the `CXCallController` to perform. This will then invoke the same `provier:performSetMutedCallAction:` method that pressing the mute button from the CallKitUI does. This then calls the actual logic in the view controller to mute the local audio track.