### PR TITLE
ISDK-2356: Implement reconnecting state callbacks

### DIFF
--- a/ARKitExample/ViewController.swift
+++ b/ARKitExample/ViewController.swift
@@ -217,6 +217,14 @@ extension ViewController: TVIRoomDelegate {
         self.setNeedsUpdateOfHomeIndicatorAutoHidden()
     }
 
+    func room(_ room: TVIRoom, isReconnectingWithError error: Error?) {
+        print("Reconnecting to room \(room.name), error = \(String(describing: error))")
+    }
+
+    func didReconnect(to room: TVIRoom) {
+        print("Reconnected to room \(room.name)")
+    }
+
     func room(_ room: TVIRoom, participantDidConnect participant: TVIRemoteParticipant) {
         print("Participant \(participant.identity) connected to \(room.name).")
     }

--- a/ARKitExample/ViewController.swift
+++ b/ARKitExample/ViewController.swift
@@ -217,7 +217,7 @@ extension ViewController: TVIRoomDelegate {
         self.setNeedsUpdateOfHomeIndicatorAutoHidden()
     }
 
-    func room(_ room: TVIRoom, isReconnectingWithError error: Error?) {
+    func room(_ room: TVIRoom, isReconnectingWithError error: Error) {
         print("Reconnecting to room \(room.name), error = \(String(describing: error))")
     }
 

--- a/AudioDeviceExample/ViewController.swift
+++ b/AudioDeviceExample/ViewController.swift
@@ -485,7 +485,7 @@ extension ViewController : TVIRoomDelegate {
         self.showRoomUI(inRoom: false)
     }
 
-    func room(_ room: TVIRoom, isReconnectingWithError error: Error?) {
+    func room(_ room: TVIRoom, isReconnectingWithError error: Error) {
         logMessage(messageText: "Reconnecting to room \(room.name), error = \(String(describing: error))")
     }
 

--- a/AudioDeviceExample/ViewController.swift
+++ b/AudioDeviceExample/ViewController.swift
@@ -305,6 +305,7 @@ class ViewController: UIViewController {
     }
 
     func logMessage(messageText: String) {
+        NSLog(messageText)
         messageLabel.text = messageText
 
         if (messageLabel.alpha < 1.0) {
@@ -482,6 +483,14 @@ extension ViewController : TVIRoomDelegate {
         self.room = nil
 
         self.showRoomUI(inRoom: false)
+    }
+
+    func room(_ room: TVIRoom, isReconnectingWithError error: Error?) {
+        logMessage(messageText: "Reconnecting to room \(room.name), error = \(String(describing: error))")
+    }
+
+    func didReconnect(to room: TVIRoom) {
+        logMessage(messageText: "Reconnected to room \(room.name)")
     }
 
     func room(_ room: TVIRoom, participantDidConnect participant: TVIRemoteParticipant) {

--- a/AudioSinkExample/ViewController.swift
+++ b/AudioSinkExample/ViewController.swift
@@ -290,6 +290,7 @@ class ViewController: UIViewController {
     }
 
     func logMessage(messageText: String) {
+        NSLog(messageText)
         messageLabel.text = messageText
 
         if (messageLabel.alpha < 1.0) {
@@ -556,6 +557,14 @@ extension ViewController : TVIRoomDelegate {
         self.room = nil
 
         self.showRoomUI(inRoom: false)
+    }
+
+    func room(_ room: TVIRoom, isReconnectingWithError error: Error?) {
+        logMessage(messageText: "Reconnecting to room \(room.name), error = \(String(describing: error))")
+    }
+
+    func didReconnect(to room: TVIRoom) {
+        logMessage(messageText: "Reconnected to room \(room.name)")
     }
 
     func room(_ room: TVIRoom, participantDidConnect participant: TVIRemoteParticipant) {

--- a/AudioSinkExample/ViewController.swift
+++ b/AudioSinkExample/ViewController.swift
@@ -559,7 +559,7 @@ extension ViewController : TVIRoomDelegate {
         self.showRoomUI(inRoom: false)
     }
 
-    func room(_ room: TVIRoom, isReconnectingWithError error: Error?) {
+    func room(_ room: TVIRoom, isReconnectingWithError error: Error) {
         logMessage(messageText: "Reconnecting to room \(room.name), error = \(String(describing: error))")
     }
 

--- a/DataTrackExample/ViewController.swift
+++ b/DataTrackExample/ViewController.swift
@@ -132,6 +132,7 @@ class ViewController: UIViewController {
     }
     
     func logMessage(messageText: String) {
+        NSLog(messageText)
         messageLabel.text = messageText
     }
     
@@ -256,7 +257,7 @@ extension ViewController : TVIRoomDelegate {
     }
     
     func room(_ room: TVIRoom, didDisconnectWithError error: Error?) {
-        logMessage(messageText: "Disconncted from room \(room.name), error = \(String(describing: error))")
+        logMessage(messageText: "Disconnected from room \(room.name), error = \(String(describing: error))")
         
         for (_, drawer) in self.drawers {
             drawer.shapeLayer!.removeFromSuperlayer()
@@ -273,6 +274,14 @@ extension ViewController : TVIRoomDelegate {
         self.room = nil
         
         self.showRoomUI(inRoom: false)
+    }
+
+    func room(_ room: TVIRoom, isReconnectingWithError error: Error?) {
+        logMessage(messageText: "Reconnecting to room \(room.name), error = \(String(describing: error))")
+    }
+
+    func didReconnect(to room: TVIRoom) {
+        logMessage(messageText: "Reconnected to room \(room.name)")
     }
     
     func room(_ room: TVIRoom, participantDidConnect participant: TVIRemoteParticipant) {

--- a/DataTrackExample/ViewController.swift
+++ b/DataTrackExample/ViewController.swift
@@ -276,7 +276,7 @@ extension ViewController : TVIRoomDelegate {
         self.showRoomUI(inRoom: false)
     }
 
-    func room(_ room: TVIRoom, isReconnectingWithError error: Error?) {
+    func room(_ room: TVIRoom, isReconnectingWithError error: Error) {
         logMessage(messageText: "Reconnecting to room \(room.name), error = \(String(describing: error))")
     }
 

--- a/Podfile
+++ b/Podfile
@@ -3,7 +3,7 @@ source 'https://github.com/CocoaPods/Specs'
 workspace 'VideoQuickStart'
 
 abstract_target 'TwilioVideo' do
-  pod 'TwilioVideo', '~> 2.6'
+  pod 'TwilioVideo', '~> 2.7'
 
   target 'ARKitExample' do
     platform :ios, '11.0'

--- a/ReplayKitExample/BroadcastExtension/SampleHandler.swift
+++ b/ReplayKitExample/BroadcastExtension/SampleHandler.swift
@@ -139,7 +139,7 @@ class SampleHandler: RPBroadcastSampleHandler, TVIRoomDelegate {
         }
     }
 
-    func room(_ room: TVIRoom, isReconnectingWithError error: Error?) {
+    func room(_ room: TVIRoom, isReconnectingWithError error: Error) {
         print("Reconnecting to room \(room.name), error = \(String(describing: error))")
     }
 

--- a/ReplayKitExample/BroadcastExtension/SampleHandler.swift
+++ b/ReplayKitExample/BroadcastExtension/SampleHandler.swift
@@ -139,6 +139,14 @@ class SampleHandler: RPBroadcastSampleHandler, TVIRoomDelegate {
         }
     }
 
+    func room(_ room: TVIRoom, isReconnectingWithError error: Error?) {
+        print("Reconnecting to room \(room.name), error = \(String(describing: error))")
+    }
+
+    func didReconnect(to room: TVIRoom) {
+        print("Reconnected to room \(room.name)")
+    }
+
     func room(_ room: TVIRoom, participantDidConnect participant: TVIRemoteParticipant) {
         print("participant: ", participant.identity, " didConnect")
     }

--- a/ReplayKitExample/ReplayKitExample/ViewController.swift
+++ b/ReplayKitExample/ReplayKitExample/ViewController.swift
@@ -241,7 +241,7 @@ class ViewController: UIViewController, RPBroadcastActivityViewControllerDelegat
         }
     }
 
-    func room(_ room: TVIRoom, isReconnectingWithError error: Error?) {
+    func room(_ room: TVIRoom, isReconnectingWithError error: Error) {
         print("Reconnecting to room \(room.name), error = \(String(describing: error))")
     }
 

--- a/ReplayKitExample/ReplayKitExample/ViewController.swift
+++ b/ReplayKitExample/ReplayKitExample/ViewController.swift
@@ -241,6 +241,14 @@ class ViewController: UIViewController, RPBroadcastActivityViewControllerDelegat
         }
     }
 
+    func room(_ room: TVIRoom, isReconnectingWithError error: Error?) {
+        print("Reconnecting to room \(room.name), error = \(String(describing: error))")
+    }
+
+    func didReconnect(to room: TVIRoom) {
+        print("Reconnected to room \(room.name)")
+    }
+
     //MARK: RPScreenRecorderDelegate
     func screenRecorderDidChangeAvailability(_ screenRecorder: RPScreenRecorder) {
         // Assume we will get an error raised if we are actively broadcasting / capturing and access is "stolen".

--- a/VideoCallKitQuickStart/ViewController.swift
+++ b/VideoCallKitQuickStart/ViewController.swift
@@ -381,7 +381,7 @@ extension ViewController : TVIRoomDelegate {
         self.showRoomUI(inRoom: false)
     }
 
-    func room(_ room: TVIRoom, isReconnectingWithError error: Error?) {
+    func room(_ room: TVIRoom, isReconnectingWithError error: Error) {
         logMessage(messageText: "Reconnecting to room \(room.name), error = \(String(describing: error))")
     }
 

--- a/VideoCallKitQuickStart/ViewController.swift
+++ b/VideoCallKitQuickStart/ViewController.swift
@@ -354,7 +354,7 @@ extension ViewController : TVIRoomDelegate {
     }
     
     func room(_ room: TVIRoom, didDisconnectWithError error: Error?) {
-        logMessage(messageText: "Disconncted from room \(room.name), error = \(String(describing: error))")
+        logMessage(messageText: "Disconnected from room \(room.name), error = \(String(describing: error))")
 
         if !self.userInitiatedDisconnect, let uuid = room.uuid, let error = error {
             var reason = CXCallEndedReason.remoteEnded
@@ -379,6 +379,14 @@ extension ViewController : TVIRoomDelegate {
         self.callKitCompletionHandler!(false)
         self.room = nil
         self.showRoomUI(inRoom: false)
+    }
+
+    func room(_ room: TVIRoom, isReconnectingWithError error: Error?) {
+        logMessage(messageText: "Reconnecting to room \(room.name), error = \(String(describing: error))")
+    }
+
+    func didReconnect(to room: TVIRoom) {
+        logMessage(messageText: "Reconnected to room \(room.name)")
     }
     
     func room(_ room: TVIRoom, participantDidConnect participant: TVIRemoteParticipant) {

--- a/VideoQuickStart/ViewController.swift
+++ b/VideoQuickStart/ViewController.swift
@@ -300,6 +300,7 @@ class ViewController: UIViewController {
     }
     
     func logMessage(messageText: String) {
+        NSLog(messageText)
         messageLabel.text = messageText
     }
 }
@@ -327,7 +328,7 @@ extension ViewController : TVIRoomDelegate {
     }
     
     func room(_ room: TVIRoom, didDisconnectWithError error: Error?) {
-        logMessage(messageText: "Disconncted from room \(room.name), error = \(String(describing: error))")
+        logMessage(messageText: "Disconnected from room \(room.name), error = \(String(describing: error))")
         
         self.cleanupRemoteParticipant()
         self.room = nil
@@ -340,6 +341,14 @@ extension ViewController : TVIRoomDelegate {
         self.room = nil
         
         self.showRoomUI(inRoom: false)
+    }
+
+    func room(_ room: TVIRoom, isReconnectingWithError error: Error?) {
+        logMessage(messageText: "Reconnecting to room \(room.name), error = \(String(describing: error))")
+    }
+
+    func didReconnect(to room: TVIRoom) {
+        logMessage(messageText: "Reconnected to room \(room.name)")
     }
     
     func room(_ room: TVIRoom, participantDidConnect participant: TVIRemoteParticipant) {

--- a/VideoQuickStart/ViewController.swift
+++ b/VideoQuickStart/ViewController.swift
@@ -343,7 +343,7 @@ extension ViewController : TVIRoomDelegate {
         self.showRoomUI(inRoom: false)
     }
 
-    func room(_ room: TVIRoom, isReconnectingWithError error: Error?) {
+    func room(_ room: TVIRoom, isReconnectingWithError error: Error) {
         logMessage(messageText: "Reconnecting to room \(room.name), error = \(String(describing: error))")
     }
 


### PR DESCRIPTION
This PR implements the reconnecting state callbacks `TVIRoomDelegate room(_ room: TVIRoom, isReconnectingWithError error: Error?)` and `TVIRoomDelegate didReconnect(to room: TVIRoom)` and picks up the 2.7 release. Also fixes a typo and consistently logs to the console in the `logMessage(messageText:)` method.