### PR TITLE
ISDK-2386: Update check for Room.state in AudioSinkExample.

### DIFF
--- a/AudioSinkExample/ViewController.swift
+++ b/AudioSinkExample/ViewController.swift
@@ -371,11 +371,13 @@ class ViewController: UIViewController {
             stopRecognizingAudio()
         } else if let audioTrack = self.localAudioTrack {
             // Known issue - local audio is not available in a Peer-to-Peer Room unless there are >= 1 RemoteParticipants.
-            
-            if (self.room?.state == TVIRoomState.connected) {
+
+            if let room = self.room,
+                room.state == .connected || room.state == .reconnecting {
+
                 if let view = self.camera?.previewView {
                     showSpeechRecognitionUI(view: view,
-                                            message: "Listening to \(room?.localParticipant?.identity ?? "yourself")...")
+                                            message: "Listening to \(room.localParticipant?.identity ?? "yourself")...")
                 }
 
                 recognizeAudio(audioTrack: audioTrack, identifier: audioTrack.name)


### PR DESCRIPTION
In AudioSinkExample, once you are connected to a Room it is valid to begin recognizing your own Participant. Similarly, reconnecting doesn't impact the ability for AudioSink to vend samples from your own LocalAudioTrack.