### PR TITLE
Fix: Made it so that it reads the JWT and sends the appropriate strin…

### DIFF
--- a/VideoQuickStart.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
+++ b/VideoQuickStart.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>IDEDidComputeMac32BitWarning</key>
+	<true/>
+</dict>
+</plist>

--- a/VideoQuickStart/ViewController.swift
+++ b/VideoQuickStart/ViewController.swift
@@ -127,6 +127,17 @@ class ViewController: UIViewController {
                 logMessage(messageText: message)
                 return
             }
+            
+            do {
+                let data = accessToken.data(using: .utf8)!
+                guard let json = try JSONSerialization.jsonObject(with: data, options: .mutableContainers) as? [String: Any] else { return }
+                let token = Token(json: json)
+                accessToken = token.token ?? ""
+            } catch {
+                let message = "Failed to extract token from json object"
+                logMessage(messageText: message)
+                return
+            }
         }
         
         // Prepare local media which we will share with Room Participants.


### PR DESCRIPTION
**Context:**
Following this tutorial on YouTube: https://www.youtube.com/watch?v=5lrdYBLEk60
This is a proposal for a small fix I noticed when trying to pass the token for establishing a connection.

**Error:**
```
20101 Invalid Access Token.
```

**Reason For Error:**
The reason is because it's not passing just the JWT but the full payload for the JSON string.

Ex:
```
"{"token\":\"ey.....\"}"
```

**Fix Includes:**
Very primitive fix for just reading the JSON data and assigning the token value to `accessToken`.

<!-- Describe your Pull Request -->

**Contributing to Twilio**

> All third party contributors acknowledge that any contributions they provide will be made under the same open source license that the open source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.
