### PR TITLE
ISDK-2455: Update ReplayKitExample for subscription APIs (2.10.0)

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -3,7 +3,7 @@ source 'https://github.com/CocoaPods/Specs'
 workspace 'VideoQuickStart'
 
 abstract_target 'TwilioVideo' do
-  pod 'TwilioVideo', '~> 2.9'
+  pod 'TwilioVideo', '~> 2.10'
 
   target 'ARKitExample' do
     platform :ios, '11.0'

--- a/ReplayKitExample/BroadcastExtension/SampleHandler.swift
+++ b/ReplayKitExample/BroadcastExtension/SampleHandler.swift
@@ -16,6 +16,7 @@ class SampleHandler: RPBroadcastSampleHandler, TVIRoomDelegate {
     var audioTrack: TVILocalAudioTrack?
     var videoSource: ReplayKitVideoSource?
     var screenTrack: TVILocalVideoTrack?
+    var disconnectSemaphore: DispatchSemaphore?
 
     var accessToken: String = "TWILIO_ACCESS_TOKEN"
     let accessTokenUrl = "http://127.0.0.1:5000/"
@@ -23,7 +24,7 @@ class SampleHandler: RPBroadcastSampleHandler, TVIRoomDelegate {
     static let kBroadcastSetupInfoRoomNameKey = "roomName"
 
     // In order to save memory, we request that our source downscale its output.
-    static let kDownScaledMaxWidthOrHeight = 640
+    static let kDownScaledMaxWidthOrHeight = 960
 
     // Which kind of audio samples we will capture. We do not mix multiple types of samples together.
     static let kAudioSampleType = RPSampleBufferType.audioMic
@@ -74,6 +75,13 @@ class SampleHandler: RPBroadcastSampleHandler, TVIRoomDelegate {
             // We have observed that downscaling the input and using H.264 results in the lowest memory usage.
             builder.preferredVideoCodecs = [TVIH264Codec()]
 
+            /*
+             * A broadcast extension has no need to subscribe to Tracks, and connects as a publish-only
+             * Participant. In a Group Room, this options saves memory and bandwidth since decoders and receivers are
+             * no longer needed. Note that subscription events will not be raised for remote publications.
+             */
+            builder.isAutomaticSubscriptionEnabled = false
+
             // The name of the Room where the Client will attempt to connect to. Please note that if you pass an empty
             // Room `name`, the Client will create one for you. You can get the name or sid from any connected Room.
             if #available(iOS 12.0, *) {
@@ -104,10 +112,15 @@ class SampleHandler: RPBroadcastSampleHandler, TVIRoomDelegate {
 
     override func broadcastFinished() {
         // User has requested to finish the broadcast.
-        self.room?.disconnect()
-        self.audioTrack = nil
-        self.videoSource = nil
-        self.screenTrack = nil
+        DispatchQueue.main.async {
+            self.room?.disconnect()
+        }
+        self.disconnectSemaphore?.wait()
+        DispatchQueue.main.sync {
+            self.audioTrack = nil
+            self.videoSource = nil
+            self.screenTrack = nil
+        }
     }
 
     override func processSampleBuffer(_ sampleBuffer: CMSampleBuffer, with sampleBufferType: RPSampleBufferType) {
@@ -133,6 +146,8 @@ class SampleHandler: RPBroadcastSampleHandler, TVIRoomDelegate {
     // MARK:- TVIRoomDelegate
     func didConnect(to room: TVIRoom) {
         print("didConnectToRoom: ", room)
+
+        disconnectSemaphore = DispatchSemaphore(value: 0)
     }
 
     func room(_ room: TVIRoom, didFailToConnectWithError error: Error) {
@@ -141,6 +156,9 @@ class SampleHandler: RPBroadcastSampleHandler, TVIRoomDelegate {
     }
 
     func room(_ room: TVIRoom, didDisconnectWithError error: Error?) {
+        if let semaphore = self.disconnectSemaphore {
+            semaphore.signal()
+        }
         if let theError = error {
             print("room: ", room, "didDisconnectWithError: ", theError)
             finishBroadcastWithError(theError)

--- a/ReplayKitExample/BroadcastExtension/SampleHandler.swift
+++ b/ReplayKitExample/BroadcastExtension/SampleHandler.swift
@@ -24,9 +24,12 @@ class SampleHandler: RPBroadcastSampleHandler, TVIRoomDelegate {
     static let kBroadcastSetupInfoRoomNameKey = "roomName"
 
     // In order to save memory, we request that our source downscale its output.
-    static let kDownScaledMaxWidthOrHeight = 960
+    static let kDownScaledMaxWidthOrHeight = 720
 
-    // Which kind of audio samples we will capture. We do not mix multiple types of samples together.
+    // Maximum bitrate (in kbps) used to send video.
+    static let kMaxVideoBitrate = UInt(1400)
+
+    // Which kind of audio samples we will capture. The example does not mix multiple types of samples together.
     static let kAudioSampleType = RPSampleBufferType.audioMic
 
     override func broadcastStarted(withSetupInfo setupInfo: [String : NSObject]?) {
@@ -74,6 +77,13 @@ class SampleHandler: RPBroadcastSampleHandler, TVIRoomDelegate {
 
             // We have observed that downscaling the input and using H.264 results in the lowest memory usage.
             builder.preferredVideoCodecs = [TVIH264Codec()]
+
+            /*
+             * Constrain the bitrate to improve QoS for subscribers when simulcast is not used, and to reduce overall
+             * bandwidth usage for the broadcaster.
+             */
+            builder.encodingParameters = TVIEncodingParameters(audioBitrate: 0,
+                                                               videoBitrate: UInt(1024) * SampleHandler.kMaxVideoBitrate)
 
             /*
              * A broadcast extension has no need to subscribe to Tracks, and connects as a publish-only

--- a/ReplayKitExample/README.md
+++ b/ReplayKitExample/README.md
@@ -14,7 +14,7 @@ Use an `RPBroadcastSampleHandler` to receive audio and video samples. Video samp
 
 An iOS 12.0 extension is not limited to capturing the screen of a single application. In fact, it is possible to capture video from any application including the home screen.
 
-In order to reduce memory usage, the extension configures `ReplayKitVideoSource` to downscsale incoming video frames, and prefers the H.264 video codec. In a Group Room, the extension connects as a publish-only Participant ([ConnectOptionsBuilder.isAutomaticSubscriptionEnabled]()) to further reduce bandwidth, memory, and CPU requirements.
+In order to reduce memory usage, the extension configures `ReplayKitVideoSource` to downscsale incoming video frames, and prefers the H.264 video codec. In a Group Room, the extension connects as a publish-only Participant ([TVIConnectOptionsBuilder.automaticSubscriptionEnabled](https://twilio.github.io/twilio-video-ios/docs/latest/Classes/TVIConnectOptionsBuilder.html#//api/name/automaticSubscriptionEnabled)) to further reduce bandwidth, memory, and CPU requirements.
 
 **ReplayKitVideoSource**
 

--- a/ReplayKitExample/README.md
+++ b/ReplayKitExample/README.md
@@ -4,15 +4,17 @@ The project demonstrates how to integrate Twilio's Programmable Video SDK with `
 
 **Conferencing (In-App)**
 
-Use `RPScreenRecorder` to capture the screen and play/record audio using `TVIDefaultAudioDevice`. After joining a Room you will be able to hear other Participants, and they will be able to hear you, and see the contents of your screen.
+Use an `RPScreenRecorder` to capture the screen and play/record audio using `TVIDefaultAudioDevice`. After joining a Room you will be able to hear other Participants, and they will be able to hear you, and see the contents of your screen.
 
 When using the in-process `RPScreenRecorder` APIs, you may only capture content from your own application. Screen capture is suspended upon entering the backround. Once you being capturing, your application is locked to its current interface orientation.
 
 **Broadcast (Extension)**
 
-Use an `RPBroadcastSampleHandler` to receive audio and video samples. Video samples are routed to `ReplayKitVideoSource`, while `ExampleReplayKitAudioCapturer` handles audio. In order to reduce memory usage, the extension configures the capturer to downscsale the incoming video frames and prefers the use of the H.264 codec.
+Use an `RPBroadcastSampleHandler` to receive audio and video samples. Video samples are routed to `ReplayKitVideoSource`, while `ExampleReplayKitAudioCapturer` handles audio.
 
 An iOS 12.0 extension is not limited to capturing the screen of a single application. In fact, it is possible to capture video from any application including the home screen.
+
+In order to reduce memory usage, the extension configures `ReplayKitVideoSource` to downscsale incoming video frames, and prefers the H.264 video codec. In a Group Room, the extension connects as a publish-only Participant ([ConnectOptionsBuilder.isAutomaticSubscriptionEnabled]()) to further reduce bandwidth, memory, and CPU requirements.
 
 **ReplayKitVideoSource**
 
@@ -59,11 +61,11 @@ Tapping "Start Conference" begins capturing and sharing the screen from within t
 
 **1. Memory Usage**
 
-Memory usage in a ReplayKit Broadcast Extension is limited to 50 MB (as of iOS 12.0). There are cases where Twilio Video can use more than this amount, especially when capturing larger 2x and 3x retina screens. This example uses format requests to reduce the amount of memory needed by our process.
+The memory usage of a ReplayKit Broadcast Extension is limited to 50 MB (as of iOS 12.2). There are cases where Twilio Video can use more than this amount, especially when capturing larger 2x and 3x retina screens in a Peer-to-Peer Room. This example uses format requests, and H.264 to reduce the amount of memory needed by the extension.
 
 <kbd><img width="400px" src="../images/quickstart/replaykit-extension-memory.png"/></kbd>
 
-We have observed that using the H.264 video codec, and a Group Room incurs the lowest memory cost.
+It is highly recommended that you use Group Rooms with your ReplayKit extension, because the extension may connect without subscribing to Tracks.
 
 **2. Application Audio Delay**
 

--- a/ReplayKitExample/README.md
+++ b/ReplayKitExample/README.md
@@ -54,7 +54,7 @@ Tapping "Start Conference" begins capturing and sharing the screen from within t
 
 1. Support capturing both application and microphone audio at the same time, in an extension. Down-mix the resulting audio samples into a single stream.
 2. Share the camera using ReplayKit, or `TVICameraSource`.
-3. Resolve tearing issues when scrolling vertically.
+3. Resolve tearing issues when scrolling vertically, and image corruption when sharing video. (ISDK-2478)
 4. Quantize ReplayKit video timestamps and use them to drop from 60 / 120 fps peaks to a lower rate (15 / 30).
 
 ### Known Issues

--- a/ReplayKitExample/ReplayKitExample/ReplayKitVideoSource.swift
+++ b/ReplayKitExample/ReplayKitExample/ReplayKitVideoSource.swift
@@ -84,7 +84,7 @@ class ReplayKitVideoSource: NSObject, TVIVideoSource {
             assertionFailure("SampleBuffer did not have an ImageBuffer")
             return
         }
-        // We only support NV12 (full-range) buffers.
+        // The source only supports NV12 (full-range) buffers.
         let pixelFormat = CVPixelBufferGetPixelFormatType(sourcePixelBuffer);
         if (pixelFormat != kCVPixelFormatType_420YpCbCr8BiPlanarFullRange) {
             assertionFailure("Extension assumes the incoming frames are of type NV12")
@@ -203,7 +203,7 @@ class ReplayKitVideoSource: NSObject, TVIVideoSource {
     static func imageOrientationToVideoOrientation(imageOrientation: CGImagePropertyOrientation) -> TVIVideoOrientation {
         let videoOrientation: TVIVideoOrientation
 
-        // Note: We do not attempt to "undo" mirroring. So far I have not encountered mirrored tags from ReplayKit sources.
+        // Note: The source does not attempt to "undo" mirroring. So far I have not encountered mirrored tags from ReplayKit sources.
         switch imageOrientation {
         case .up:
             videoOrientation = TVIVideoOrientation.up


### PR DESCRIPTION
This PR updates ReplayKitExample to use the new `ConnectOptionsBuilder.isAutomaticSubscriptionEnabled` API (2.10.0).

#### Description

* Update Podfile for 2.10
* Update SampleHandler to use `builder.isAutomaticSubscriptionEnabled = false`
* Increase maximum dimension from 640 -> 960. The extension has more predictable memory usage now
* Wait for Room disconnection when ending a broadcast
* Update README.md content

#### Validation

I was able to validate the changes in Xcode by connecting several Participants sharing audio + video. All this time my extension continued to consume negligible downstream bandwidth and memory usage remained flat.