### PR TITLE
ISDK-2470 - CallKitQS was accessing UIKit in background thread in CallKit Action

### DIFF
--- a/VideoCallKitQuickStart/ViewController.swift
+++ b/VideoCallKitQuickStart/ViewController.swift
@@ -173,11 +173,13 @@ class ViewController: UIViewController {
             let transaction = CXTransaction(action: muteAction)
 
             callKitCallController.request(transaction)  { error in
-                if let error = error {
-                    self.logMessage(messageText: "SetMutedCallAction transaction request failed: \(error.localizedDescription)")
-                    return
+                DispatchQueue.main.async {
+                    if let error = error {
+                        self.logMessage(messageText: "SetMutedCallAction transaction request failed: \(error.localizedDescription)")
+                        return
+                    }
+                    self.logMessage(messageText: "SetMutedCallAction transaction request successful")
                 }
-                self.logMessage(messageText: "SetMutedCallAction transaction request successful")
             }
         }
     }


### PR DESCRIPTION
 CallKitQS was accessing UIKit in background thread in CallKit Action was causing the crash.

**Contributing to Twilio**

> All third party contributors acknowledge that any contributions they provide will be made under the same open source license that the open source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.
